### PR TITLE
Accessibility improvements

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -130,7 +130,7 @@
             Dev Bootcamp's apprenticeship team
           </a>
         </li>
-      </p>
+      </ul>
     </dd>
 
     <dt>Any advice for me if I want to mentor apprentices at my organization?</dt>
@@ -152,7 +152,7 @@
           If you haven't pair programmed much (say, 100 hours) before,
           get a few more hours of pair programming under your belt.
         </li>
-      </p>
+      </ul>
     </dd>
   </dl>
 </section>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -10,12 +10,11 @@
     <script src="//use.typekit.net/uic8vfj.js"></script>
     <script>try{Typekit.load();}catch(e){}</script>
   </head>
-
   <body class="<%= page_classes %>">
-    <main>
-      <%= partial "partials/header" %>
+    <%= partial "partials/header" %>
+    <main role="main">
       <%= yield %>
-      <%= partial "partials/footer" %>
     </main>
+    <%= partial "partials/footer" %>
   </body>
 </html>

--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="site-footer">
+<footer class="site-footer" role="contentinfo">
   <p>
     apprentice.io © <%= Date.current.year %>
     <a href="https://thoughtbot.com">thoughtbot, inc.</a>

--- a/source/partials/_header.html.erb
+++ b/source/partials/_header.html.erb
@@ -2,5 +2,5 @@
   <h1 class="brand-logo">
     <a href="/">apprentice.io</a>
   </h1>
-  <h2 class="from">Community resources for software apprenticeships</h2>
+  <p class="from">Community resources for software apprenticeships</p>
 </header>

--- a/source/partials/_header.html.erb
+++ b/source/partials/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="site-header">
+<header class="site-header" role="banner">
   <h1 class="brand-logo">
     <a href="/">apprentice.io</a>
   </h1>

--- a/source/stylesheets/_header.scss
+++ b/source/stylesheets/_header.scss
@@ -13,7 +13,6 @@
 }
 
 .from {
-  color: lighten($base-font-color, 55%);
   font-family: $base-font-family;
   font-size: em(18);
   font-style: italic;

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -53,7 +53,7 @@ p {
 a {
   @include transition(color 0.1s linear);
   color: $base-link-color;
-  text-decoration: none;
+  text-decoration-skip: ink;
 
   &:hover {
     color: $hover-link-color;


### PR DESCRIPTION
- Fix invalid HTML
- Add `lang` attribute to `html` element
  - Declaring the language attribute on the `html` element allows
    assistive technology to understand the human language of the page.
    Screen readers use this information to read out the text with correct
    pronunciation.
  - Marking the language can also assist user agents in providing
    definitions using a dictionary.
- Fix color contrast of text
  - By increasing the contrast between foreground and background colors we
    help those with low vision impairments and color deficiencies read and
    navigate our content.
  - This change meets WCAG 2.0 AA contrast ratio thresholds and removes 1
    violations thrown by [axe-core](https://github.com/dequelabs/axe-core)
    when run on the home page.
- Improve headings outline
  - Properly marked up headings provide semantic meaning to things like
    assistive technology. They also allow screen readers to navigate
    through headings, providing screen reader users an efficient way to
    find and parse content. Skipping heading levels, or marking up
    non-headings in heading elements can lead to confusion.
  - This commit changes the page's subtitle to a paragraph, rather than an
    `h2`, because it is not a heading which represents content below it in
    an outline.
- Add ARIA landmarks
  - Landmarks help establish the semantic structure of the document. Some
    assistive technologies like screen readers surface them to the user and
    allow them to navigate using them.
  - See: https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html
- Stop removing underlines on links
  - By relying only on color to indicate links, it can be difficult for
    those with low vision to understand what text is a link.

cc: @thoughtbot/accessibility 