### PR TITLE
Fix weird spacing after experiences link

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -57,9 +57,7 @@
       </ul>
       <p>
         Hear from the folks running these programs
-        <a href="https://medium.com/@kamrinklauschie/apprenticeships-101-what-we-learned-from-our-panel-with-linkedin-pinterest-airbnb-and-adobe-4305d65ddbdd">
-          about their experiences
-        </a>.
+        <a href="https://medium.com/@kamrinklauschie/apprenticeships-101-what-we-learned-from-our-panel-with-linkedin-pinterest-airbnb-and-adobe-4305d65ddbdd">about their experiences</a>.
       </p>
     </dd>
 


### PR DESCRIPTION
Browsers appear to be doing something weird to the "about their experiences"
`<a>` tag, where there's a space appended between the tag and the
following period (presumably due to carriage returns around the tag
content.

The space results in odd line wrapping where the period follows on a
separate line when the viewport is narrow, and adds an extra space
between the link text and the period ending the sentence when
the viewport is wide.