### PR TITLE
License content as Creative Commons, code as MIT

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright (c) 2017 thoughtbot and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ Push to master.
 [Netlify] will automatically deploy the site to <https://www.apprentice.io>.
 
 [Netlify]: https://www.netlify.com/
+
+## License
+
+The content of this project
+is licensed under the [Creative Commons Attribution 4.0 license][CC].
+The underlying source code used to format and display that content
+is licensed under the [MIT license][MIT].
+
+[CC]: https://creativecommons.org/licenses/by/4.0/
+[MIT]: http://opensource.org/licenses/mit-license.php

--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -1,7 +1,9 @@
 <footer class="site-footer content-wrapper" role="contentinfo">
   <p>
-    apprentice.io © <%= Date.current.year %>
-    <a href="https://thoughtbot.com">thoughtbot, inc.</a>
+    This work is licensed under a
+    <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+      Creative Commons Attribution 4.0 International License
+    </a>
   </p>
   <p>
     <a href="https://github.com/thoughtbot/apprenticeio">Edit this page</a>

--- a/source/stylesheets/components/_footer.scss
+++ b/source/stylesheets/components/_footer.scss
@@ -1,5 +1,5 @@
 .site-footer {
-  @include padding($base-spacing null);
+  @include padding($base-spacing 0);
   border-top: $base-border;
   font-size: modular-scale(-1);
   margin-top: $large-spacing;


### PR DESCRIPTION
While discussing this site with a community member,
they were unsure of whether to contribute to apprentice.io
because of the copyright.

This change uses a Creative Commons license for the content
and MIT license for the code.

I based the content vs. code distinction on:

https://choosealicense.com/
https://github.com/github/choosealicense.com/blob/gh-pages/README.md#license

Looking at the old Playbook code,
we used to use a Non-Commercial variant for that content
but this license as proposed allows for commercial use.