### PR TITLE
Increase max duration to 12 months

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -3,7 +3,7 @@
     <dt>What is a typical software apprenticeship?</dt>
     <dd>
       <p>
-        A 3-6 month program for product designers or software engineers
+        A 3-12 month program for product designers or software engineers
         to be trained by mentors in order to become permanent employees
         at the organization by the end of the apprenticeship.
       </p>
@@ -14,7 +14,7 @@
       <p>
         On-the-job training.
         Accepted into a company based on potential for a permanent role
-        3-6 months from today instead of experience today.
+        3-12 months from today instead of experience today.
         <a href="http://www.sfchronicle.com/business/article/Tech-apprenticeships-bring-new-talent-into-11125436.php">Pursue your dreams!</a>
       </p>
     </dd>


### PR DESCRIPTION
These apprenticeship programs are longer than 6 months:

* 8th Light (5-8 months for resident)
* Pinterest (12 months)