### PR TITLE
Remove references to apprentice.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# apprentice.io
+# apprentice.thoughtbot.com
 
-This is the source of [apprentice.io], which is a Middleman app.
+This is the source of [apprentice.thoughtbot.com], which is a Middleman app.
 
-[apprentice.io]: https://apprentice.thoughtbot.com/
+[apprentice.thoughtbot.com]: https://apprentice.thoughtbot.com/
 
 ## Set up
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,7 +5,7 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>apprentice.io</title>
+    <title>apprentice.thoughtbot.com</title>
     <link type="image/ico" href="/favicon.ico" rel="icon" />
     <%= stylesheet_link_tag "application" %>
   </head>

--- a/source/partials/_header.html.erb
+++ b/source/partials/_header.html.erb
@@ -1,4 +1,4 @@
 <header class="site-header content-wrapper" role="banner">
-  <h1>apprentice.io</h1>
+  <h1>apprentice.thoughtbot.com</h1>
   <p class="from">Community resources for software apprenticeships</p>
 </header>


### PR DESCRIPTION
We’re no longer using that branding, and the domain isn’t ours.

This came from a discussion on thoughtbot/apprenticeship#40.

I'm not certain a straight text change for apprentice.thoughtbot.com is the right thing to do in all cases (is there a better title we could use?) Opening the PR as a place to discuss.